### PR TITLE
Fix jupyter bundlerextension on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
+    - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
 
 requirements:
   host:
@@ -52,6 +53,7 @@ test:
     - jupyter notebook -h
     - jupyter nbextension -h
     - jupyter serverextension -h
+    - jupyter bundlerextension -h
   imports:
     - notebook
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main


### PR DESCRIPTION
A few weeks I found an issue with `jupyter bundlerextension` on Windows which seems to be related to the build process for Windows, because if you install `notebook` via pip everything is fine.

Therefore I submitted a PR to [conda-forge/notebook-feedstock](https://github.com/conda-forge/notebook-feedstock) which fixed the issue for me: https://github.com/conda-forge/notebook-feedstock/pull/24

I have also submitted a PR (https://github.com/ContinuumIO/anaconda-recipes/pull/132) to the old [ContinuumIO/anaconda-recipes](https://github.com/ContinuumIO/anaconda-recipes), but the repository is deprecated and therefore the PR not merged.

This repository is a fork of [conda-forge/notebook-feedstock](https://github.com/conda-forge/notebook-feedstock), but you do not merge all commits of it. Therefore here you have my separate PR for fixing the issue in this repository.