### PR TITLE
fix Navigator - Jupyter-notebook launch issue with fish shell on Mac

### DIFF
--- a/recipe/jupyter_mac.command
+++ b/recipe/jupyter_mac.command
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 DIR=$(dirname $0)
 
 $DIR/jupyter-notebook


### PR DESCRIPTION
Issue: https://github.com/ContinuumIO/anaconda-issues/issues/8222 

This fix is also mentioned in the issue. 

Tested on my Mac. 
