### PR TITLE
notebook 6.4.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ app:
 test:
   requires:
     - pip
+    - requests
   commands:
     - python -m pip check
     - jupyter notebook -h


### PR DESCRIPTION
Update notebook to 6.4.5

Category: anaconda
Version change: bump from 6.4.3 to 6.4.5
Changelog: https://github.com/jupyter/notebook/blob/master/CHANGELOG.md
Upstream Issues: https://github.com/jupyter/notebook/issues
Requirements: https://github.com/jupyter/notebook/blob/v6.4.5/pyproject.toml and
https://github.com/jupyter/notebook/blob/v6.4.5/setup.py 
License: https://github.com/jupyter/notebook/blob/master/LICENSE
The package builds correctly

Actions:
1. Update skip: True  # [py<37]
2. Update test/imports
3. Add `requests `to test/requires

Result:
- all-succeeded