### PR TITLE
notebook 6.4.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.4.5" %}
+{% set version = "6.4.6" %}
 
 package:
   name: notebook
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/notebook/notebook-{{ version }}.tar.gz
-  sha256: 872e20da9ae518bbcac3e4e0092d5bd35454e847dedb8cb9739e9f3b68406be0
+  sha256: 7bcdf79bd1cda534735bd9830d2cbedab4ee34d8fe1df6e7b946b3aab0902ba3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,13 @@ requirements:
     - jupyter_client >=5.3.4
     - nbconvert
     - nbformat
+    - nest-asyncio >=1.5
+    - prometheus_client
     - pyzmq >=17
-    - send2trash >=1.5.0
+    - send2trash >=1.8.0
     - terminado >=0.8.3
     - tornado >=6.1
     - traitlets >=4.2.1
-    - prometheus_client
 
 app:
   entry: jupyter-notebook  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - wheel
     - jupyter-packaging >=0.9
   run:
-    - python
+    - python >=3.7
     - argon2-cffi
     - ipykernel
     - ipython_genutils


### PR DESCRIPTION
Update notebook to 6.4.6

This version fixes asyncio error when opening notebooks https://github.com/jupyter/notebook/commit/751c7eb0cc7d252e5ee3a378056c6eee107445a1