### PR TITLE
notebook 6.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "notebook" %}
 {% set version = "6.4.8" %}
 
 package:
-  name: notebook
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/n/notebook/notebook-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
   sha256: 1e985c9dc6f678bdfffb9dc657306b5469bfa62d73e03f74e8defbf76d284312
 
 build:
@@ -15,7 +16,7 @@ build:
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
     - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
-  skip: true  # [py<37]
+  skip: true  # [py<36]
 
 requirements:
   host:
@@ -23,9 +24,9 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - jupyter-packaging >=0.9
+    - jupyter-packaging >=0.9,<1.0
   run:
-    - python >=3.7
+    - python >=3.6
     - argon2-cffi
     - ipykernel
     - ipython_genutils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.4.6" %}
+{% set version = "6.4.8" %}
 
 package:
   name: notebook
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/notebook/notebook-{{ version }}.tar.gz
-  sha256: 7bcdf79bd1cda534735bd9830d2cbedab4ee34d8fe1df6e7b946b3aab0902ba3
+  sha256: 1e985c9dc6f678bdfffb9dc657306b5469bfa62d73e03f74e8defbf76d284312
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - traitlets >=4.2.1
 
 app:
-  entry: jupyter-notebook  # [not osx]
+  entry: jupyter-notebook                        # [not osx]
   entry: open ${PREFIX}/bin/jupyter_mac.command  # [osx]
   icon: jupyter.png
   summary: Jupyter Notebook

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,18 +21,18 @@ build:
 requirements:
   host:
     - python
+    - jupyter-packaging >=0.9,<1.0
     - pip
     - setuptools
     - wheel
-    - jupyter-packaging >=0.9,<1.0
   run:
-    - python >=3.6
+    - python
     - argon2-cffi
     - ipykernel
     - ipython_genutils
     - jinja2
-    - jupyter_core >=4.6.1
     - jupyter_client >=5.3.4
+    - jupyter_core >=4.6.1
     - nbconvert
     - nbformat
     - nest-asyncio >=1.5


### PR DESCRIPTION
Update notebook to 6.4.8

Version change: bump version number from 6.4.6 to 6.4.8
Bug Tracker: new open issues https://github.com/jupyter/notebook/issues
Upstream license:  License file:  https://github.com/jupyter/notebook/blob/master/LICENSE
Upstream Changelog: https://github.com/jupyter/notebook/blob/master/CHANGELOG.md
Upstream setup.py:  https://github.com/jupyter/notebook/blob/v6.4.8/setup.py
Upstream pyproject.toml:  https://github.com/jupyter/notebook/blob/v6.4.8/pyproject.toml

Actions:
1. Use jinja2 templates in source/url
2. Skip `py<36`
3. Use` jupyter-packaging >=0.9,<1.0` in `host`
4. Fix python in `run` and `host`

Result:
- all-succeeded