### PR TITLE
notebook 6.4.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.4.8" %}
+{% set version = "6.4.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 1e985c9dc6f678bdfffb9dc657306b5469bfa62d73e03f74e8defbf76d284312
+  sha256: 709b1856a564fe53054796c80e17a67262071c86bfbdfa6b96aaa346113c555a
 
 build:
   number: 0
-  # trigger 1
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
     - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
-  skip: true  # [py<36]
+  skip: true  # [py<37]
 
 requirements:
   host:
@@ -34,7 +33,7 @@ requirements:
     - jinja2
     - jupyter_client >=5.3.4
     - jupyter_core >=4.6.1
-    - nbconvert
+    - nbconvert >=5
     - nbformat
     - nest-asyncio >=1.5
     - prometheus_client


### PR DESCRIPTION
Version change: bump version number from 6.4.8 to 6.4.11
Bug Tracker: new open issues https://github.com/jupyter/notebook/issues
Upstream license: License file: https://github.com/jupyter/notebook/blob/master/LICENSE
Upstream Changelog: https://github.com/jupyter/notebook/blob/master/CHANGELOG.md
Upstream setup.py: https://github.com/jupyter/notebook/blob/v6.4.11/setup.py
Upstream pyproject.toml: https://github.com/jupyter/notebook/blob/v6.4.11/pyproject.toml

Actions:
1. Skip p`y<37`
2. Add pinning for `nbconvert`