### PR TITLE
notebook 6.4.12

### DIFF
--- a/recipe/jupyter_mac.command
+++ b/recipe/jupyter_mac.command
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 DIR=$(dirname $0)
 
 $DIR/jupyter-notebook

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.4.11" %}
+{% set version = "6.4.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 709b1856a564fe53054796c80e17a67262071c86bfbdfa6b96aaa346113c555a
+  sha256: 6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86
 
 build:
   number: 0


### PR DESCRIPTION
Address CVE-2022-29238

Version change: bump version number from 6.4.11 to 6.4.12
Bug Tracker: new open issues https://github.com/jupyter/notebook/issues
License: https://github.com/jupyter/notebook/blob/master/LICENSE
Changelog: https://github.com/jupyter/notebook/blob/master/CHANGELOG.md
Requirements:
- https://github.com/jupyter/notebook/blob/6.4.12/setup.py
- https://github.com/jupyter/notebook/blob/6.4.12/pyproject.toml

Actions:
1. Fix `jupyter_mac.command` is not executable with `fish`, see https://github.com/ContinuumIO/anaconda-issues/issues/8222#issuecomment-386795363