### PR TITLE
notebook 6.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.4.12" %}
+{% set version = "6.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86
+  sha256: c1897e5317e225fc78b45549a6ab4b668e4c996fd03a04e938fe5e7af2bfffd0
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-647](https://anaconda.atlassian.net/browse/PKG-647) (notebook-6.5.2)

**The upstream data:**
Github releases:  https://github.com/jupyter/notebook/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/notebook/compare/6.4.12...6.5.2)
License: https://github.com/jupyter/notebook/blob/master/LICENSE
Changelog: https://github.com/jupyter/notebook/blob/main/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/jupyter/notebook/blob/v6.5.2/setup.py
 *  pyproject.toml:  https://github.com/jupyter/notebook/blob/v6.5.2/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * Requires `nbclassic >=0.4.7`

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 6.5.2
 * Release on PyPi:
    * version: 6.5.2
    * date: 2022-10-30T06:48:21
* [PyPi history](https://pypi.org/project/notebook/#history)
 * Popularity: 
    * 3 months downloads: 1669697.0
    * All time:  10581219 downloads -  notebook  6.5.2  A web-based notebook environment for interactive computing  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyter/notebook/tree/v6.5.2 exists
2. - [x] https://jupyter.org is present
3. - [ ] Check the pinnings
4. - [x] https://github.com/jupyter/notebook/blob/main/CHANGELOG.md exists
5. - [ ] Additional research
    https://github.com/jupyter/notebook/issues
    200
6. - [x] `dev_url` is present
    https://github.com/jupyter/notebook
7. - [ ] `doc_url` error:
    https://jupyter-notebook.readthedocs.io
    302
7. - [ ] `doc_source_url` error:
    https://github.com/jupyter/notebook/tree/master/docs
    302
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [ ] NO `pip` in test
    python
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present
16. - [x] License: BSD-3-Clause
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

17. - [x] license_family BSD is present
</details>

