### PR TITLE
notebook 6.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.4.12" %}
+{% set version = "6.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86
+  sha256: c5b747b047aa934da5f8f52d3b7219e7338684890d8dd6d9cac5d67d4513f924
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 645b98b..3a616eb 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.4.12" %}
+{% set version = "6.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86
+  sha256: c5b747b047aa934da5f8f52d3b7219e7338684890d8dd6d9cac5d67d4513f924
 
 build:
   number: 0

```

<details>
<summary><b>Recipe directory diff between current conda-forge/master and this update</b></summary>

``` diff
Feedstock not rebased against upstream
```
</details>

**Links:**
* [Concourse pipeline](https://concourse.build.corp.continuum.io/teams/main/pipelines/auto-build-notebook-6.5.0)
* [Update branch](https://github.com/AnacondaRecipes/notebook-feedstock/tree/6.5.0)
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/notebook-feedstock)
* [None feedstock](https://github.com/None/notebook-feedstock)
* [PyPI](https://pypi.org/project/notebook)
* [Diff between upstream and feature branch](https://github.com/conda-forge/notebook-feedstock/compare/main...AnacondaRecipes:6.5.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/notebook-feedstock/compare/master...AnacondaRecipes:6.5.0)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified.Note that the PR diffs are not updated with these changes.
```
git clone -b 6.5.0 git@github.com:AnacondaRecipes/notebook-feedstock.git
```
or
```
git clone -b 6.5.0 https://github.com/AnacondaRecipes/notebook-feedstock.git
