### PR TITLE
notebook 6.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,29 @@
 {% set name = "notebook" %}
-{% set version = "6.4.12" %}
+{% set version = "6.5.2" %}
+{% set min_nbclassic = "0.4.7" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: 6268c9ec9048cff7a45405c990c29ac9ca40b0bc3ec29263d218c5e01f2b4e86
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c1897e5317e225fc78b45549a6ab4b668e4c996fd03a04e938fe5e7af2bfffd0
 
 build:
   number: 0
+  skip: true  # [py<37]
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
     - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
-  skip: true  # [py<37]
 
 requirements:
   host:
     - python
-    - jupyter-packaging >=0.9,<1.0
+    - jupyter-packaging
+    - nbclassic
     - pip
     - setuptools
     - wheel
@@ -33,6 +35,7 @@ requirements:
     - jinja2
     - jupyter_client >=5.3.4
     - jupyter_core >=4.6.1
+    - nbclassic >={{ min_nbclassic }}
     - nbconvert >=5
     - nbformat
     - nest-asyncio >=1.5
@@ -59,6 +62,7 @@ test:
   requires:
     - pip
     - requests
+    - nbclassic >={{ min_nbclassic }}
   commands:
     - python -m pip check
     - jupyter notebook -h
@@ -77,7 +81,6 @@ about:
   summary: A web-based notebook environment for interactive computing
   dev_url: https://github.com/jupyter/notebook
   doc_url: https://jupyter-notebook.readthedocs.io
-  doc_source_url: https://github.com/jupyter/notebook/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A web-based notebook environment for interactive computing
+  description: |
+    The Jupyter notebook is a web-based notebook environment for interactive computing.
   dev_url: https://github.com/jupyter/notebook
   doc_url: https://jupyter-notebook.readthedocs.io
 


### PR DESCRIPTION
**Jira ticket:** [PKG-647](https://anaconda.atlassian.net/browse/PKG-647) (notebook-6.5.2)

**The upstream data:**
Github releases:  https://github.com/jupyter/notebook/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/notebook/compare/6.4.12...6.5.2)
License: https://github.com/jupyter/notebook/blob/master/LICENSE
Changelog: https://github.com/jupyter/notebook/blob/main/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/jupyter/notebook/blob/v6.5.2/setup.py
 *  pyproject.toml:  https://github.com/jupyter/notebook/blob/v6.5.2/pyproject.toml

**_Actions:_**

1. Skip `py<37`
2. Remove pinning of `jupyter-packaging`
3. Add `nbclassic` to `host`, `run` and `test/requires`
4. Add `description`
5. Remove `doc_source_url`

**_Notes:_**
 * Requires `nbclassic >=0.4.7`

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 6.5.2
 * Release on PyPi:
    * version: 6.5.2
    * date: 2022-10-30T06:48:21
* [PyPi history](https://pypi.org/project/notebook/#history)
 * Popularity: 
    * 3 months downloads: 1669697.0
    * All time:  10581219 downloads -  notebook  6.5.2  A web-based notebook environment for interactive computing  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyter/notebook/tree/v6.5.2 exists
6. - [x] https://jupyter.org is present
7. - [ ] Check the pinnings
8. - [x] https://github.com/jupyter/notebook/blob/main/CHANGELOG.md exists
9. - [x] Additional research
    https://github.com/jupyter/notebook/issues
    200
10. - [x] `dev_url` is present
    https://github.com/jupyter/notebook
11. - [x] `doc_url` error:
    https://jupyter-notebook.readthedocs.io
    302
12. - [x] Verify that the `build_number` is correct
13. - [x] has `setuptools`
14. - [x] has `wheel`
15. - [x] `pip` in test
16. - [x] Verify the test section
17. - [x] Verify if the package is `architecture specific`
18. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
19.  - [x] license_file: LICENSE is present
20. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has a correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

21. - [x] license_family BSD is present
</details>

