### PR TITLE
update to 6.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.5.3" %}
+{% set version = "6.5.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b12bee3292211d85dd7e588a790ddce30cb3e8fbcfa1e803522a207f60819e05
+  sha256: 517209568bd47261e2def27a140e97d49070602eea0d226a696f42a7f16c9a4e
 
 build:
   number: 0


### PR DESCRIPTION
 update notebook-feedstock  6.5.3 -> 6.5.4
 - all remains the same checked with upstream
 jira: https://anaconda.atlassian.net/browse/PKG-1546
