### PR TITLE
Update to 7.0.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ requirements:
     - python
     - hatchling >=1.11
     - hatch-jupyter-builder >=0.5
-    - jupyterlab >=4.0.2,<5
+    - jupyterlab >=4.0.7,<5
     - pip
   run:
     - python
     - jupyter_server >=2.4.0,<3
-    - jupyterlab >=4.0.2,<5
+    - jupyterlab >=4.0.7,<5
     - jupyterlab_server >=2.22.1,<3
     - notebook-shim >=0.2,<0.3
     - tornado >=6.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "7.0.6" %}
+{% set version = "7.0.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/notebook-{{ version }}.tar.gz
-  sha256: ec6113b06529019f7f287819af06c97a2baf7a95ac21a8f6e32192898e9f9a58
+  sha256: 3bcff00c17b3ac142ef5f436d50637d936b274cfa0b41f6ac0175363de9b4e09
 
 build:
   number: 0


### PR DESCRIPTION
Notebook 7.0.7

**Destination channel**: defaults

### Links
[Upstream repository](https://github.com/jupyter/notebook)
[Upstream changelog/diff](https://github.com/jupyter/notebook/compare/v7.0.6...v7.0.7)

### Explanation of changes:
Notebook 7.0.7 includes High and Moderate severity security fixes [(GH release)](https://github.com/jupyter/notebook/releases/tag/v7.0.7)
Changes made in line with those made on conda-forge https://github.com/conda-forge/notebook-feedstock/pull/142/files
