### PR TITLE
PKG-4692

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: False

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
 aggregate_check: False
+
+channels:
+  - https://staging.continuum.io/prefect/fs/nbclassic-feedstock/pr13/dda04f2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_check: False
-
-channels:
-  - https://staging.continuum.io/prefect/fs/nbclassic-feedstock/pr13/c838b4d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 aggregate_check: False
 
 channels:
-  - https://staging.continuum.io/prefect/fs/nbclassic-feedstock/pr13/dda04f2
+  - https://staging.continuum.io/prefect/fs/nbclassic-feedstock/pr13/c838b4d

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "6.5.4" %}
+{% set version = "6.5.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 517209568bd47261e2def27a140e97d49070602eea0d226a696f42a7f16c9a4e
+  sha256: 04eb9011dfac634fbd4442adaf0a8c27cd26beef831fe1d19faf930c327768e4
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<37]
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
@@ -39,7 +39,7 @@ requirements:
     - nbformat
     - nest-asyncio >=1.5
     - prometheus_client
-    - pyzmq >=17,<25
+    - pyzmq >=17
     - send2trash >=1.8.0
     - terminado >=0.8.3
     - tornado >=6.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37 or s390x]
+  skip: true  # [py<37 or py>=312]
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<37 or s390x]
   entry_points:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
@@ -22,7 +22,7 @@ requirements:
   host:
     - python
     - jupyter-packaging 0.12.0
-    - nbclassic 0.4.8
+    - nbclassic >=0.4.0
     - pip
     - setuptools
     - wheel


### PR DESCRIPTION
Update notebook 6 branch to latest version 6.5.7. Skipping 3.12 has we won't build version 6 for 3.12.

https://github.com/jupyter/notebook/tree/v6.5.7
https://github.com/jupyter/notebook/blob/v6.5.7/CHANGELOG.md

https://github.com/AnacondaRecipes/nbclassic-feedstock/pull/13