### PR TITLE
Use `%CONDA_ROOT_PREFIX%` as an additional fallback location for `menuinst`

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,17 +5,17 @@ REM menu file so that conda picks it up when running menuinst.
 SET "MENU_DIR=%PREFIX%\Menu"
 IF NOT EXIST "%MENU_DIR%" MKDIR "%MENU_DIR%"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v1.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak"
+copy "%RECIPE_DIR%\menu-v1.json" "%MENU_DIR%\%PKG_NAME%_menu-v1.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak"
+copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu-v2.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu.json"
 if errorlevel 1 exit 1
 copy "%RECIPE_DIR%\jupyter.ico" "%MENU_DIR%\jupyter.ico"
 if errorlevel 1 exit 1
 
-%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+"%PYTHON%" -m pip install . --no-deps --no-build-isolation -vv
 
 if errorlevel 1 exit 1
 
-rd /s /q %SCRIPTS%
+rd /s /q "%SCRIPTS%"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,17 @@
-REM Prepare shortcuts. menuinst v2 shortcuts should only be used startings
+REM Prepare shortcuts. menuinst v2 shortcuts should only be used starting
 REM at menuinst v2.1.1 due to bugs. The post-link script
 REM will handle which shortcut to use. One file needs to be the default
 REM menu file so that conda picks it up when running menuinst.
-SET MENU_DIR=%PREFIX%\Menu
-IF NOT EXIST %MENU_DIR% mkdir %MENU_DIR%
+SET "MENU_DIR=%PREFIX%\Menu"
+IF NOT EXIST "%MENU_DIR%" MKDIR "%MENU_DIR%"
 if errorlevel 1 exit 1
-copy %RECIPE_DIR%\menu-v1.json %MENU_DIR%\%PKG_NAME%_menu-v1.json.bak
+copy "%RECIPE_DIR%\menu-v1.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak"
 if errorlevel 1 exit 1
-copy %RECIPE_DIR%\menu-v2.json %MENU_DIR%\%PKG_NAME%_menu-v2.json.bak
+copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak"
 if errorlevel 1 exit 1
-copy %RECIPE_DIR%\menu-v2.json %MENU_DIR%\%PKG_NAME%_menu.json
+copy "%RECIPE_DIR%\menu-v2.json" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 if errorlevel 1 exit 1
-copy %RECIPE_DIR%\jupyter.ico %MENU_DIR%\jupyter.ico
+copy "%RECIPE_DIR%\jupyter.ico" "%MENU_DIR%\jupyter.ico"
 if errorlevel 1 exit 1
 
 %PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 705e83a1785f45b383bf3ee13cb76680b92d24f56fb0c7d2136fe1d850cd3ca8
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38 or s390x]
   entry_points:
     - jupyter-notebook = notebook.app:main

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -18,7 +18,10 @@ IF EXIST "%CONDA_PYTHON_EXE%" (
 REM The CONDA_PYTHON_EXE variable is not set for installers, so use conda-standalone.
 IF EXIST "%PREFIX%\_conda.exe" (
     SET PYTHON_CMD="%PREFIX%\_conda.exe" python
-    SET CONDA_STANDALONE=1
+    GOTO :get_menuinst
+)
+IF EXIST "%CONDA_ROOT_PREFIX%\_conda.exe" (
+    SET PYTHON_CMD="%CONDA_ROOT_PREFIX%\_conda.exe" python
     GOTO :get_menuinst
 )
 GOTO :use_menuinst_v1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,9 +3,9 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 REM The menuinst v2 json file is not compatible with menuinst versions
 REM older than 2.1.1. Copy the appropriate file as the menu file.
 
-SET LOGFILE=%PREFIX%\.messages.txt
-SET MENU_DIR=%PREFIX%\Menu
-SET MENU_PATH=%MENU_DIR%\%PKG_NAME%_menu.json
+SET "LOGFILE=%PREFIX%\.messages.txt"
+SET "MENU_DIR=%PREFIX%\Menu"
+SET "MENU_PATH=%MENU_DIR%\%PKG_NAME%_menu.json"
 
 
 REM Determine menuinst version.
@@ -42,7 +42,7 @@ IF %ERRORLEVEL% == 0 (
 GOTO :exit
 
 :patch
-    SET TMPMENU=%MENU_DIR%\%PKG_NAME%_menu_tmp.json
+    SET "TMPMENU=%MENU_DIR%\%PKG_NAME%_menu_tmp.json"
     SET FINDREPLACE=%~1
     FOR /f "delims=" %%i IN ('type "%MENU_PATH%"') DO (
         SET s=%%i


### PR DESCRIPTION
notebook 7.3.2

**Destination channel:** defaults

### Links

- [PKG-8387](https://anaconda.atlassian.net/browse/PKG-8387) 
- [Upstream repository](https://github.com/jupyter/notebook)


### Explanation of changes:

- For installers, `%PREFIX%\_conda.exe` is only available when the package is installed into the `base` environment. Use `%CONDA_ROOT_PREFIX%` (which points to the base environment) as an additional fallback.
- Improve quoting of variables to handle paths with spaces.


[PKG-8387]: https://anaconda.atlassian.net/browse/PKG-8387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ