### PR TITLE
PKG-15089: Update notebook to 7.5.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "7.5.5" %}
+{% set version = "7.5.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: dc0bfab0f2372c8278c457423d3256c34154ac2cc76bf20e9925260c461013c3
+  sha256: 621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1
 
 build:
   number: 0
@@ -23,11 +23,11 @@ requirements:
     - pip
     - hatchling >=1.11
     - hatch-jupyter-builder >=0.5
-    - jupyterlab >=4.5.6,<4.6
+    - jupyterlab >=4.5.7,<4.6
   run:
     - python
     - jupyter_server >=2.4.0,<3
-    - jupyterlab >=4.5.6,<4.6
+    - jupyterlab >=4.5.7,<4.6
     - jupyterlab_server >=2.28.0,<3
     - notebook-shim <0.3,>=0.2
     - tornado >=6.2.0


### PR DESCRIPTION
## notebook 7.5.6

**Destination channel:** defaults

### Links
- [PKG-15089](https://anaconda.atlassian.net/browse/PKG-15089)
- [PyPI](https://pypi.org/project/notebook/7.5.6/)
- [GitHub](https://github.com/jupyter/notebook)

### Explanation of changes:
- Updated notebook from 7.5.5 to 7.5.6
- Bumped `jupyterlab` pin from `>=4.5.6,<4.6` to `>=4.5.7,<4.6` (both host and run)

[PKG-15089]: https://anaconda.atlassian.net/browse/PKG-15089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ