### PR TITLE
update to 7.5.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "notebook" %}
-{% set version = "7.5.6" %}
+{% set version = "7.5.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1
+  sha256: d6d59288a25303b25e1dcb71e9b017ec3a785f7d92f38b9bc288ca1970d5b0a8
 
 build:
   number: 0
@@ -23,11 +23,11 @@ requirements:
     - pip
     - hatchling >=1.11
     - hatch-jupyter-builder >=0.5
-    - jupyterlab >=4.5.7,<4.6
+    - jupyterlab >=4.5.8,<4.6
   run:
     - python
     - jupyter_server >=2.4.0,<3
-    - jupyterlab >=4.5.7,<4.6
+    - jupyterlab >=4.5.8,<4.6
     - jupyterlab_server >=2.28.0,<3
     - notebook-shim <0.3,>=0.2
     - tornado >=6.2.0


### PR DESCRIPTION
notebook 7.5.7

**Destination channel:** defaults

### Links
- [PKG-16362](https://anaconda.atlassian.net/browse/PKG-16362)
- [PyPI](https://pypi.org/project/notebook/7.5.7/)

### Explanation of changes:
- Updated notebook from 7.5.6 to 7.5.7
- Refreshed the PyPI source hash
- Updated dependency bounds where upstream metadata changed


[PKG-16362]: https://anaconda.atlassian.net/browse/PKG-16362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ